### PR TITLE
fix: baseActivity에서 padding때문에 UI가 상단까지 붙지 않는 문제 해결

### DIFF
--- a/app/src/main/java/com/example/beering/feature/MainActivity.kt
+++ b/app/src/main/java/com/example/beering/feature/MainActivity.kt
@@ -10,6 +10,7 @@ import com.example.beering.feature.my.MyFragment
 import com.example.beering.R
 import com.example.beering.databinding.ActivityMainBinding
 import com.example.beering.util.base.BaseActivity
+import com.example.beering.util.ignoreRootPadding
 import com.kakao.sdk.common.util.Utility
 
 class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::inflate) {
@@ -17,6 +18,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
     override fun initAfterBinding() {
         installSplashScreen()
         initBottomNavigation()
+
         Log.d("test", "keyhash : ${Utility.getKeyHash(this)}")
 
     }

--- a/app/src/main/java/com/example/beering/feature/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/beering/feature/home/HomeFragment.kt
@@ -43,8 +43,8 @@ class HomeFragment: Fragment() {
         }
 
         // statusbar margin 필요한 부분만 추가적으로 매서드 적용
-        binding.homeSearchEt.addStatusMarginTop(requireContext())
-        binding.homeScanIv.addStatusMarginTop(requireContext())
+        binding.homeSearchEt.addStatusBarMarginTop(requireContext())
+        binding.homeScanIv.addStatusBarMarginTop(requireContext())
 
         // api 연결
         homeService.getReviews().enqueue(object : retrofit2.Callback<ReviewsResponse>{

--- a/app/src/main/java/com/example/beering/feature/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/beering/feature/home/HomeFragment.kt
@@ -12,9 +12,11 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.beering.databinding.FragmentHomeBinding
 import com.example.beering.feature.review.reviewDetail.ReviewDetailActivity
+import com.example.beering.util.addStatusMarginTop
 import com.example.beering.util.getAccessToken
 import com.example.beering.util.getRetrofit_header
 import com.example.beering.util.getRetrofit
+import com.example.beering.util.ignoreRootPadding
 import com.example.beering.util.stateLogin
 import com.example.beering.util.token.token
 import retrofit2.Call
@@ -39,6 +41,10 @@ class HomeFragment: Fragment() {
         }else{
             homeService = getRetrofit().create(ReviewsApiService::class.java)
         }
+
+        // statusbar margin 필요한 부분만 추가적으로 매서드 적용
+        binding.homeSearchEt.addStatusMarginTop(requireContext())
+        binding.homeScanIv.addStatusMarginTop(requireContext())
 
         // api 연결
         homeService.getReviews().enqueue(object : retrofit2.Callback<ReviewsResponse>{

--- a/app/src/main/java/com/example/beering/feature/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/beering/feature/home/HomeFragment.kt
@@ -12,11 +12,10 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.beering.databinding.FragmentHomeBinding
 import com.example.beering.feature.review.reviewDetail.ReviewDetailActivity
-import com.example.beering.util.addStatusMarginTop
+import com.example.beering.util.addStatusBarMarginTop
 import com.example.beering.util.getAccessToken
 import com.example.beering.util.getRetrofit_header
 import com.example.beering.util.getRetrofit
-import com.example.beering.util.ignoreRootPadding
 import com.example.beering.util.stateLogin
 import com.example.beering.util.token.token
 import retrofit2.Call

--- a/app/src/main/java/com/example/beering/util/WindowParams.kt
+++ b/app/src/main/java/com/example/beering/util/WindowParams.kt
@@ -5,10 +5,15 @@ import android.content.Context
 import android.os.Build
 import android.util.Log
 import android.view.View
+import android.view.ViewGroup
 import android.view.WindowManager
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.marginBottom
+import androidx.core.view.marginLeft
+import androidx.core.view.marginRight
+import androidx.core.view.marginTop
 
 fun Context.statusBarHeight(): Int {
     val resourceId = resources.getIdentifier("status_bar_height", "dimen", "android")
@@ -39,4 +44,17 @@ fun Activity.setStatusBarTransparent() {
 fun dpToPx(dp: Int, context: Context): Int {
     val density = context.resources.displayMetrics.density
     return (dp * density).toInt()
+}
+
+// Statusbar padding 무시하고 최상단에 딱 붙여야 하는 경우
+fun View.ignoreRootPadding(context : Context){
+    val param = layoutParams as ViewGroup.MarginLayoutParams
+    param.setMargins(marginLeft, -context.statusBarHeight(), marginRight, marginBottom)
+    layoutParams = param
+}
+
+fun View.addStatusMarginTop(context : Context){
+    val param = layoutParams as ViewGroup.MarginLayoutParams
+    param.setMargins(marginLeft,marginTop + context.statusBarHeight(), marginRight, marginBottom)
+    layoutParams = param
 }

--- a/app/src/main/java/com/example/beering/util/WindowParams.kt
+++ b/app/src/main/java/com/example/beering/util/WindowParams.kt
@@ -53,7 +53,7 @@ fun View.ignoreRootPadding(context : Context){
     layoutParams = param
 }
 
-fun View.addStatusMarginTop(context : Context){
+fun View.addStatusBarMarginTop(context : Context){
     val param = layoutParams as ViewGroup.MarginLayoutParams
     param.setMargins(marginLeft,marginTop + context.statusBarHeight(), marginRight, marginBottom)
     layoutParams = param

--- a/app/src/main/java/com/example/beering/util/base/BaseActivity.kt
+++ b/app/src/main/java/com/example/beering/util/base/BaseActivity.kt
@@ -7,7 +7,11 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.marginBottom
+import androidx.core.view.marginLeft
+import androidx.core.view.marginRight
 import androidx.core.view.marginTop
 import androidx.viewbinding.ViewBinding
 import com.example.beering.util.navigationHeight
@@ -15,13 +19,14 @@ import com.example.beering.util.setStatusBarTransparent
 import com.example.beering.util.statusBarHeight
 
 abstract class BaseActivity<T: ViewBinding>(private val inflate: (LayoutInflater) -> T): AppCompatActivity() {
-    lateinit var binding: T
+    private var _binding: T? = null
+    protected val binding get() = _binding!!
 
     private var imm: InputMethodManager? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = inflate(layoutInflater)
+        _binding = inflate(layoutInflater)
         setContentView(binding.root)
         setStatusBarTransparent()
 //         상태 바, 네비게이션 높이 만큼 padding 주기
@@ -31,7 +36,7 @@ abstract class BaseActivity<T: ViewBinding>(private val inflate: (LayoutInflater
             }
             setPadding(
                 0,
-                this@BaseActivity.statusBarHeight(),
+                0,
                 0,
                 this@BaseActivity.navigationHeight()
             )
@@ -65,10 +70,9 @@ abstract class BaseActivity<T: ViewBinding>(private val inflate: (LayoutInflater
         imm?.hideSoftInputFromWindow(v.windowToken, 0)
     }
 
-//    fun View.ignoreRootPadding(){
-//        marginTop =
-//    }
-
+    fun showToast(message: String) {
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+    }
 }
 
 

--- a/app/src/main/java/com/example/beering/util/base/BaseFragment.kt
+++ b/app/src/main/java/com/example/beering/util/base/BaseFragment.kt
@@ -1,0 +1,42 @@
+package com.example.beering.util.base
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.viewbinding.ViewBinding
+
+typealias Inflate<T> = (LayoutInflater, ViewGroup?, Boolean) -> T
+abstract class BaseFragment<T: ViewBinding>(private val inflate: Inflate<T>): Fragment() {
+
+    private var _binding: T? = null
+    protected val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = inflate.invoke(inflater, container, false)
+
+        if (binding.root is ViewGroup){
+            (binding.root as ViewGroup).clipToPadding = false
+        }
+        initAfterBinding()
+        return binding.root
+    }
+
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    protected abstract fun initAfterBinding()
+
+    fun showToast(message: String) {
+        Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,6 +10,7 @@
         android:id="@+id/main_frm"
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:clipChildren="false"
         app:layout_constraintBottom_toTopOf="@id/main_bnv"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -23,6 +24,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        app:elevation="0dp"
         app:menu="@menu/bottom_nav_menu" />
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #72 

## 📝작업 내용

> StatusBar만큼 paddingTop 주는 부분 없애고 marginTop 주는 함수 추가했습니다.
- WindowParams에 addStatusBarMarginTop() 매서드 확인해주세요. 해당 뷰에 statusbar 만큼 margintop 추가해주는 매서드 입니다.
- 기본적으로 Activity에서 padding적용 안되기 때문에 매 UI마다 marginTop 주도록 처리해주어야 합니다. (다소 귀찮을 순 있으나 padding으로 인한 고질적인 문제는 해결됨) -> 어차피 한줄만 추가하면 되요 ^~^
> BaseFragment 클래스 추가했습니다.



## 💬리뷰 요구사항(선택)

> StatusBar marginTop 관련해서 일단 HomeFragment에만 적용해놨는데 해당 부분 확인 후 다른 UI에도 각자 적용해주세요
- Statusbar 아래쪽부터 UI 시작한다 생각하고 UI 구성 후 최상단 View에만 StatusbarMarginTop 만큼 더해주면 됩니다. (ConstraintLayout으로 작성하는거 추천드려요)

> BaseFragment를 추가해놨는데 적용은 안시켰습니다. 각자 코드 확인 후 적절히 적용해주세요 (BaseActivity랑 동작원리 동일)
